### PR TITLE
Add commands for join/leave subscriptions

### DIFF
--- a/constants/routes.go
+++ b/constants/routes.go
@@ -1,5 +1,7 @@
 package constants
 
+import "github.com/mattermost/mattermost-plugin-apps/apps"
+
 const (
 	ManifestPath = "/manifest"
 	InstallPath  = "/install"
@@ -51,6 +53,11 @@ const (
 	OtherOpenDialogUpdateResponse    = "/UpdateResponse"
 	OtherOpenDialogBadResponse       = "/BadResponse"
 
-	SubscribeBotMention = "/subscribe/bot_mention"
-	NotifyBotMention    = "/notify/bot_mention"
+	SubscribeCommand = "/subscribe"
+
+	NotifyBotMention       = "/notify/" + string(apps.SubjectBotMentioned)
+	NotifyBotJoinedChannel = "/notify/" + string(apps.SubjectBotJoinedChannel)
+	NotifyBotLeftChannel   = "/notify/" + string(apps.SubjectBotLeftChannel)
+	NotifyBotJoinedTeam    = "/notify/" + string(apps.SubjectBotJoinedTeam)
+	NotifyBotLeftTeam      = "/notify/" + string(apps.SubjectBotLeftTeam)
 )

--- a/routers/mattermost/bindings/command/main.go
+++ b/routers/mattermost/bindings/command/main.go
@@ -40,7 +40,7 @@ func Get(context *apps.Context) *apps.Binding {
 	base.Bindings = append(base.Bindings, getInvalid(siteURL, appID))
 	base.Bindings = append(base.Bindings, getError(siteURL, appID))
 	base.Bindings = append(base.Bindings, getOthers(context))
-	base.Bindings = append(base.Bindings, getSubscribeCommands(context))
+	base.Bindings = append(base.Bindings, getSubscribeCommand(context))
 
 	return out
 }

--- a/routers/mattermost/bindings/command/subscriptions.go
+++ b/routers/mattermost/bindings/command/subscriptions.go
@@ -5,46 +5,55 @@ import (
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 )
 
-func getSubscribeCommands(context *apps.Context) *apps.Binding {
-	base := &apps.Binding{
-		Location: "subscriptions",
-		Label:    "subscriptions",
-		Bindings: []*apps.Binding{},
+func makeSubscriptionOption(subject apps.Subject) apps.SelectOption {
+	return apps.SelectOption{
+		Label: string(subject),
+		Value: string(subject),
 	}
-
-	base.Bindings = append(base.Bindings, getBotMentionCommand())
-
-	return base
 }
 
-func getBotMentionCommand() *apps.Binding {
+func getSubscribeCommand(context *apps.Context) *apps.Binding {
 	return &apps.Binding{
-		Location: "bot_mention",
-		Label:    "bot_mention",
-		Bindings: []*apps.Binding{
-			{
-				Location:    "subscribe",
-				Label:       "subscribe",
-				Description: "Subscribe to bot mention subscriptions",
-				Form:        &apps.Form{},
-				Call: &apps.Call{
-					Path:  constants.SubscribeBotMention,
-					State: true,
-					Expand: &apps.Expand{
-						AdminAccessToken: apps.ExpandAll,
-					},
+		Location: "subscriptions",
+		Label:    "subscriptions",
+		Form: &apps.Form{
+			Call: &apps.Call{
+				Path:  constants.SubscribeCommand,
+				State: true,
+				Expand: &apps.Expand{
+					AdminAccessToken: apps.ExpandAll,
 				},
 			},
-			{
-				Location:    "unsubscribe",
-				Label:       "unsubscribe",
-				Description: "Unsubscribe from bot mention subscriptions",
-				Form:        &apps.Form{},
-				Call: &apps.Call{
-					Path:  constants.SubscribeBotMention,
-					State: false,
-					Expand: &apps.Expand{
-						AdminAccessToken: apps.ExpandAll,
+			Fields: []*apps.Field{
+				{
+					Name:                 "subject",
+					Label:                "subject",
+					IsRequired:           true,
+					AutocompletePosition: 1,
+					Type:                 apps.FieldTypeStaticSelect,
+					SelectStaticOptions: []apps.SelectOption{
+						makeSubscriptionOption(apps.SubjectBotMentioned),
+						makeSubscriptionOption(apps.SubjectBotJoinedChannel),
+						makeSubscriptionOption(apps.SubjectBotLeftChannel),
+						makeSubscriptionOption(apps.SubjectBotJoinedTeam),
+						makeSubscriptionOption(apps.SubjectBotLeftTeam),
+					},
+				},
+				{
+					Name:                 "subscribe",
+					Label:                "subscribe",
+					IsRequired:           true,
+					AutocompletePosition: 2,
+					Type:                 apps.FieldTypeStaticSelect,
+					SelectStaticOptions: []apps.SelectOption{
+						{
+							Label: "subscribe",
+							Value: "subscribe",
+						},
+						{
+							Label: "unsubscribe",
+							Value: "unsubscribe",
+						},
 					},
 				},
 			},

--- a/routers/mattermost/fSubscriptions.go
+++ b/routers/mattermost/fSubscriptions.go
@@ -3,6 +3,7 @@ package mattermost
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/mattermost/mattermost-app-test/utils"
@@ -12,24 +13,59 @@ import (
 	"github.com/pkg/errors"
 )
 
-func fSubscriptionsCommandBotMention(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
+type SubscriptionsCommandFormValues struct {
+	Subject struct {
+		Label apps.Subject `json:"label"`
+		Value apps.Subject `json:"value"`
+	} `json:"subject"`
+
+	Subscribe struct {
+		Label string `json:"label"`
+		Value string `json:"value"`
+	} `json:"subscribe"`
+}
+
+func unmarshalSubscriptionsCommandFormValues(form map[string]interface{}) (*SubscriptionsCommandFormValues, error) {
+	b, err := json.Marshal(form)
+	if err != nil {
+		return nil, err
+	}
+
+	values := &SubscriptionsCommandFormValues{}
+
+	err = json.Unmarshal(b, values)
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+func fSubscriptionsCommand(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
 	return func(w http.ResponseWriter, r *http.Request, c *apps.CallRequest) {
 		context := c.Context
 		client := mmclient.AsAdmin(context)
 
-		subscribe, _ := c.State.(bool)
+		values, err := unmarshalSubscriptionsCommandFormValues(c.Values)
+		if err != nil {
+			utils.WriteCallErrorResponse(w, errors.Wrap(err, "failed to unmarshal command submission into form values").Error())
+			return
+		}
 
+		path := "/notify/" + string(values.Subject.Value)
 		sub := &apps.Subscription{
-			Subject: apps.SubjectBotMentioned,
+			Subject: values.Subject.Value,
 			AppID:   context.AppID,
-			Call:    apps.NewCall("/notify/bot_mention"),
+			Call:    apps.NewCall(path),
 		}
 
 		message := ""
+		subscribe := values.Subscribe.Value == "subscribe"
+
 		if subscribe {
 			_, err := client.Subscribe(sub)
 			if err != nil {
-				err = errors.Wrap(err, "failed to subscribe to bot_mention notifications.")
+				err = errors.Wrapf(err, "failed to subscribe to %v notifications.", values.Subject)
 				b, _ := json.Marshal(c)
 
 				err = errors.Wrap(err, string(b))
@@ -39,40 +75,133 @@ func fSubscriptionsCommandBotMention(m *apps.Manifest) func(http.ResponseWriter,
 				return
 			}
 
-			message = "Successfully subscribed to bot_mention notifications."
+			message = fmt.Sprintf("Successfully subscribed to %v notifications.", values.Subject)
 		} else {
 			_, err := client.Unsubscribe(sub)
 			if err != nil {
-				err = errors.Wrap(err, "failed to unsubscribe from bot_mention notifications.")
+				err = errors.Wrapf(err, "failed to unsubscribe from %v notifications.", values.Subject)
 				cr := apps.NewErrorCallResponse(err)
 				json.NewEncoder(w).Encode(cr)
 
 				return
 			}
 
-			message = "Successfully unsubscribed from bot_mention notifications."
+			message = fmt.Sprintf("Successfully unsubscribed from %v notifications.", values.Subject)
 		}
 
-		member, _ := client.GetChannelMember(context.ChannelID, context.BotUserID, "")
-		if member == nil {
-			message += " I'm not a member of this channel so I won't be notified of posts mentioning me here."
-		} else {
-			message += " I'm a member of this channel so I will be notified of posts mentioning me here."
+		if values.Subject.Value == apps.SubjectBotMentioned {
+			member, _ := client.GetChannelMember(context.ChannelID, context.BotUserID, "")
+			if member == nil {
+				message += " I'm not a member of this channel so I won't be notified of posts mentioning me here."
+			} else {
+				message += " I'm a member of this channel so I will be notified of posts mentioning me here."
+			}
 		}
 
-		s := fmt.Sprintf("```\n%s\n```\n%s", c.RawCommand, message)
+		s := fmt.Sprintf("```\n%v\n```\n%v", c.RawCommand, message)
 		utils.WriteCallStandardResponse(w, s)
 	}
 }
 
 func fSubscriptionsBotMention(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
 	return func(w http.ResponseWriter, r *http.Request, c *apps.CallRequest) {
+		message := "Received `bot_mentioned` notification"
 		client := mmclient.AsBot(c.Context)
-		client.CreatePost(&model.Post{
+
+		rootID := c.Context.PostID
+		if c.Context.RootPostID != "" {
+			rootID = c.Context.RootPostID
+		}
+
+		_, err := client.CreatePost(&model.Post{
 			ChannelId: c.Context.ChannelID,
-			Message:   "Notify response",
+			RootId:    rootID,
+			Message:   message,
 		})
 
-		utils.WriteCallStandardResponse(w, "Notify response")
+		if err != nil {
+			log.Println(err.Error())
+		}
+
+		utils.WriteCallStandardResponse(w, message)
+	}
+}
+
+func fSubscriptionsBotJoinedChannel(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
+	return func(w http.ResponseWriter, r *http.Request, c *apps.CallRequest) {
+		message := "Received `bot_joined_channel` notification"
+		client := mmclient.AsBot(c.Context)
+
+		_, err := client.CreatePost(&model.Post{
+			ChannelId: c.Context.ChannelID,
+			Message:   message,
+		})
+
+		if err != nil {
+			log.Println(err.Error())
+		}
+
+		utils.WriteCallStandardResponse(w, message)
+	}
+}
+
+func fSubscriptionsBotLeftChannel(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
+	return func(w http.ResponseWriter, r *http.Request, c *apps.CallRequest) {
+		message := "Received `bot_left_channel` notification"
+		client := mmclient.AsBot(c.Context)
+
+		_, err := client.DM(c.Context.ActingUserID, message)
+		if err != nil {
+			log.Println(err.Error())
+		}
+
+		utils.WriteCallStandardResponse(w, message)
+	}
+}
+
+func fSubscriptionsBotJoinedTeam(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
+	return func(w http.ResponseWriter, r *http.Request, c *apps.CallRequest) {
+		message := "Received `bot_joined_team` notification"
+		client := mmclient.AsBot(c.Context)
+
+		channel, resp := client.GetChannelByName("town-square", c.Context.TeamID, "")
+		if resp.Error != nil {
+			log.Println(resp.Error.Error())
+			message += ", but failed to get Town Square channel: " + resp.Error.Error()
+
+			_, err := client.DM(c.Context.ActingUserID, message)
+			if err != nil {
+				log.Println(err.Error())
+			}
+
+			utils.WriteCallStandardResponse(w, message)
+
+			return
+		}
+
+		_, err := client.CreatePost(&model.Post{
+			ChannelId: channel.Id,
+			Message:   message,
+		})
+
+		if err != nil {
+			log.Println(err.Error())
+		}
+
+		utils.WriteCallStandardResponse(w, message)
+	}
+}
+
+func fSubscriptionsBotLeftTeam(m *apps.Manifest) func(http.ResponseWriter, *http.Request, *apps.CallRequest) {
+	return func(w http.ResponseWriter, r *http.Request, c *apps.CallRequest) {
+		message := "Received `bot_left_team` notification"
+		client := mmclient.AsBot(c.Context)
+
+		_, err := client.DM(c.Context.ActingUserID, message)
+		if err != nil {
+			log.Println(err.Error())
+		}
+
+		utils.WriteCallStandardResponse(w, message)
 	}
 }

--- a/routers/mattermost/mattermost.go
+++ b/routers/mattermost/mattermost.go
@@ -67,9 +67,15 @@ func Init(router *mux.Router, m *apps.Manifest, staticAssets fs.FS, localMode bo
 	// Static files
 	router.PathPrefix(constants.StaticAssetPath).Handler(http.StripPrefix("/", http.FileServer(http.FS(staticAssets))))
 
-	// Subscriptions
-	router.HandleFunc(constants.SubscribeBotMention+"/submit", extractCall(fSubscriptionsCommandBotMention(m), localMode))
+	// Subscription Commands
+	router.HandleFunc(constants.SubscribeCommand+"/submit", extractCall(fSubscriptionsCommand(m), localMode))
+
+	// Notifications
 	router.HandleFunc(constants.NotifyBotMention, extractCall(fSubscriptionsBotMention(m), localMode))
+	router.HandleFunc(constants.NotifyBotJoinedChannel, extractCall(fSubscriptionsBotJoinedChannel(m), localMode))
+	router.HandleFunc(constants.NotifyBotLeftChannel, extractCall(fSubscriptionsBotLeftChannel(m), localMode))
+	router.HandleFunc(constants.NotifyBotJoinedTeam, extractCall(fSubscriptionsBotJoinedTeam(m), localMode))
+	router.HandleFunc(constants.NotifyBotLeftTeam, extractCall(fSubscriptionsBotLeftTeam(m), localMode))
 
 	// OpenDialog
 	router.HandleFunc(constants.OtherPathOpenDialog+"/submit", extractCall(postOpenDialogTest(m), localMode))


### PR DESCRIPTION
This PR changes the `subscriptions` command to allow for subscribing to bot join/leave channel/team events. They can be accessed as:

- `/test subscriptions bot_joined_channel subscribe`
- `/test subscriptions bot_joined_channel unsubscribe`

Behavior to expect when subscriptions are active:

- `bot_mentioned` - bot should reply to the post that mentioned that bot
- `bot_joined_channel` - bot should create a post in the channel
- `bot_left_channel` - bot should DM the acting user saying that they were removed from the channel
- `bot_joined_team` - bot should create a post in "Town Square" of the team
- `bot_left_team` - bot should DM the acting user saying that they were removed from the team

This functionality is meant to help test the bot mention PR https://github.com/mattermost/mattermost-plugin-apps/pull/220